### PR TITLE
Use htmlentities as strip_tags can't handle broken html

### DIFF
--- a/jobs/CheckFeed.php
+++ b/jobs/CheckFeed.php
@@ -153,7 +153,7 @@ class CheckFeed {
   }
 
   private static function strip_html($html) {
-    return preg_replace('/\s+/',"\n",strtolower(strip_tags($html)));
+    return preg_replace('/\s+/',"\n",strtolower(htmlentities($html)));
   }
 
   private static function deliver_to_subscriber($body, $content_type, $subscriber) {


### PR DESCRIPTION
Full background at https://github.com/aaronpk/Watchtower/issues/7

The comparison would compare a lot more garbage of course, but it would at least make sure that broken html is ignored and no additional dependencies are added to the setup.